### PR TITLE
Release 0.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
   <img src="icons/icon-512.png" alt="Paperless Uploader Icon" width="256" height="256">
 </p>
 
+Available in the [Thunderbird Add-On Gallery](https://addons.thunderbird.net/addon/paperless-ngx-uploader/).
+
+
 ## Screenshots
 
 <div align="center">

--- a/manifest.json
+++ b/manifest.json
@@ -6,16 +6,17 @@
   "browser_specific_settings": {
     "gecko": {
       "id": "@paperless-uploader.sebastian-xyz",
-      "strict_min_version": "128.0"
+      "strict_min_version": "140.0"
     }
   },
   "permissions": [
     "messagesRead",
     "menus",
-    "storage",
-    "notifications"
+    "notifications",
+    "permissions",
+    "storage"
   ],
-  "host_permissions": [
+  "optional_host_permissions": [
     "http://*/*",
     "https://*/*"
   ],

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Paperless-ngx Uploader",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Upload PDF attachments directly to Paperless-ngx from Thunderbird",
   "browser_specific_settings": {
     "gecko": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paperless-upload-thunderbird",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Upload PDF attachments directly to Paperless-ngx from Thunderbird",
   "dependencies": {
     "fuse.js": "^7.1.0"

--- a/select-attachments.js
+++ b/select-attachments.js
@@ -57,7 +57,7 @@ function populateAttachmentList() {
 
     const sizeDiv = document.createElement('div');
     sizeDiv.className = 'attachment-size';
-    sizeDiv.textContent = formatFileSize(attachment.size);
+    sizeDiv.textContent = browser.messengerUtilities.formatFileSize(attachment.size);
 
     infoDiv.appendChild(nameDiv);
     infoDiv.appendChild(sizeDiv);

--- a/upload-dialog.js
+++ b/upload-dialog.js
@@ -174,7 +174,7 @@ async function loadUploadData() {
     currentAttachments.forEach(attachment => {
       const li = document.createElement('li');
       li.className = 'file-item';
-      li.textContent = `📄 ${attachment.name} (${formatFileSize(attachment.size)})`;
+      li.textContent = `📄 ${attachment.name} (${browser.messengerUtilities.formatFileSize(attachment.size)})`;
       fileList.appendChild(li);
     });
 

--- a/utils.js
+++ b/utils.js
@@ -1,17 +1,5 @@
 // Shared utility functions for Paperless-ngx PDF Uploader extension
 
-/**
- * Format file size in bytes to human readable format
- * @param {number} bytes - File size in bytes
- * @returns {string} Formatted file size string
- */
-function formatFileSize(bytes) {
-  if (bytes === 0) return '0 Bytes';
-  const k = 1024;
-  const sizes = ['Bytes', 'KB', 'MB', 'GB'];
-  const i = Math.floor(Math.log(bytes) / Math.log(k));
-  return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
-}
 
 /**
  * Display an error message in the message area
@@ -216,7 +204,6 @@ async function makePaperlessRequest(endpoint, options = {}, settings = null) {
 
 // Export functions for use in other files
 if (typeof window !== 'undefined') {
-  window.formatFileSize = formatFileSize;
   window.showError = showError;
   window.showSuccess = showSuccess;
   window.clearMessages = clearMessages;


### PR DESCRIPTION
**Permissions and Manifest Updates**

* Updated `manifest.json` to version 0.7.0
* Raised the minimum supported Thunderbird version to `140`
* added `"permissions"` to the permissions list
* switched to `"optional_host_permissions"` for site access ([Ref](https://thunderbird.topicbox.com/groups/addons/Tafa58394231a18f8-M3e565a75287313ea4395ff5f/prefer-to-use-optionalhostpermissions-to-get-around-cors-issues-with-fetch))
* Added logic in `options.js` to request and verify site permissions before saving the Paperless URL ([Ref](https://thunderbird.topicbox.com/groups/addons/Tafa58394231a18f8-M3e565a75287313ea4395ff5f/prefer-to-use-optionalhostpermissions-to-get-around-cors-issues-with-fetch))

**Code cleanup**

* Replaced the custom `formatFileSize` function with the built-in `browser.messengerUtilities.formatFileSize` in both `select-attachments.js` and `upload-dialog.js`, and removed the redundant utility function from `utils.js`.

**Documentation**

* Updated `README.md` to include a link to the Thunderbird Add-On Gallery now that the Add-On is published
