### PR TITLE
fix(network): prevent unwanted default https upgrades

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -41,5 +41,8 @@
     "128": "icons/icon-128.png",
     "16": "icons/icon-16.png",
     "32": "icons/icon-32.png"
+  },
+  "content_security_policy": {
+    "extension_pages": "script-src 'self';"
   }
 }


### PR DESCRIPTION
Background: in manifest v3 the default content_security_policy contains the `upgrade-insecure-requests` directive. This prevents fetching/uploading to paperless servers which only support http. See https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Content_Security_Policy#upgrade_insecure_network_requests_in_manifest_v3 and https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Content_Security_Policy#default_content_security_policy Fix works by explicitly stating the content_security_policy which is identical to the default one minus the upgrade-directive.

ATTENTION: this might conflict with mozillas addon security policy. See https://extensionworkshop.com/documentation/publish/add-on-policies/#security-compliance-and-blocking. Maybe there is another better way to handle this, which I did not think about.

FIXES #19 (maye #24)