### PR TITLE
fix(options): request host permission from within the user gesture

### DIFF
--- a/options.js
+++ b/options.js
@@ -11,25 +11,32 @@ async function loadSettings() {
 
 
 async function requestSitePermission(url) {
-  // Normalize the origin to ensure it ends with /*
-  const origin = url.replace(/\/?\*?$/, '/*');
-
-  const hasPermission = await browser.permissions.contains({
-    origins: [origin],
-  });
-
-  if (hasPermission) {
-    // Permission already granted \u2014 safe to save and use the URL.
-    return true;
+  // Build a valid WebExtension match pattern from the URL.
+  // Match patterns are "<scheme>://<host>/*" and MUST NOT contain a port
+  // number or path. A pattern like "http://192.168.1.111:11800/*" is invalid
+  // and makes permissions.request()/contains() reject, so we derive the origin
+  // from the parsed scheme + hostname only (a host pattern matches all ports).
+  let origin;
+  try {
+    const parsed = new URL(url);
+    origin = `${parsed.protocol}//${parsed.hostname}/*`;
+  } catch (_) {
+    // Should not happen: the caller already validated the URL.
+    return false;
   }
 
-  const granted = await browser.permissions.request({
+  // permissions.request() may only be called from a user input handler, and the
+  // user gesture is lost across any await. Awaiting permissions.contains() first
+  // therefore made this throw "permissions.request may only be called from a
+  // user input handler". Requesting directly keeps the gesture intact; when the
+  // permission is already granted, request() resolves true without prompting,
+  // so a contains() pre-check is unnecessary.
+  //
+  // Returned (not awaited) so the request is issued synchronously while the
+  // caller is still inside the submit handler.
+  return browser.permissions.request({
     origins: [origin],
   });
-
-  // If not granted, it's not safe to save or use the URL,
-  // since the user explicitly denied access.
-  return granted;
 }
 
 
@@ -49,7 +56,14 @@ async function saveSettings(event) {
 
   // Request permission for the URL if it's provided
   if (paperlessUrl) {
-    const permissionGranted = await requestSitePermission(paperlessUrl);
+    let permissionGranted = false;
+    try {
+      permissionGranted = await requestSitePermission(paperlessUrl);
+    } catch (error) {
+      showStatus('Error requesting permission for the specified URL: ' + error.message, 'error');
+      console.error('Error requesting site permission:', error);
+      return;
+    }
     if (!permissionGranted) {
       showStatus('Permission to access the specified URL was denied. Please allow access to save the settings.', 'error');
       return;


### PR DESCRIPTION
Fixes #29

Saving the settings silently failed whenever a new Paperless URL was entered — no error was shown and nothing was stored. There are two independent bugs in `requestSitePermission()`.

### 1. The user gesture was lost

`permissions.request()` may only be called from a user input handler, but the code awaited `permissions.contains()` first. The gesture does not survive an `await`, so `request()` rejected with:

```
permissions.request may only be called from a user input handler
```

Only `storage.sync.set()` was wrapped in `try/catch`, so this rejection aborted `saveSettings()` with no feedback at all — exactly the "no error message appears" symptom in #29.

The `contains()` pre-check is now removed: `request()` already resolves `true` without prompting when the permission is already held, and issuing it directly keeps the gesture intact.

### 2. The match pattern contained the port

The origin was built by string replacement:

```js
const origin = url.replace(/\/?\*?$/, '/*');   // → "http://192.168.1.111:11800/*"
```

Match patterns must not contain a port or a path, so that pattern is invalid. It is now derived from the parsed `protocol` + `hostname` (`http://192.168.1.111/*`). A host pattern matches all ports anyway, and the URL itself is still stored with its port, so API calls are unaffected.

This is why the report was specific to local IP addresses: those are typically entered with an explicit port, while a plain domain produced a valid pattern by accident.

### Error handling

The permission request is now wrapped in `try/catch` so failures surface in the UI instead of aborting silently. This is what made the underlying error visible in the first place, and it prevents any future rejection from failing quietly again.

### Verification

Tested against a stub reproducing Thunderbird's gesture requirement (`request()` throws unless invoked synchronously during event dispatch):

| | before | after |
|---|---|---|
| `request()` called synchronously | ❌ no | ✅ yes |
| requested pattern | `http://192.168.88.182:8000/*` | `http://192.168.88.182/*` |
| result | ❌ *may only be called from a user input handler* | ✅ settings saved |
| stored URL | — | `http://192.168.88.182:8000` |

The old code reproduces the reported failure exactly; the new code passes. Also confirmed manually on Thunderbird 140.13.0esr with `http://192.168.88.182:8000`.
